### PR TITLE
add pool_pre_ping=True to connection pool

### DIFF
--- a/chessticulate_api/db.py
+++ b/chessticulate_api/db.py
@@ -4,6 +4,8 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from chessticulate_api.config import CONFIG
 
-async_engine = create_async_engine(CONFIG.sql_conn_str, echo=CONFIG.sql_echo)
+async_engine = create_async_engine(
+    CONFIG.sql_conn_str, pool_pre_ping=True, echo=CONFIG.sql_echo
+)
 
 async_session = async_sessionmaker(async_engine, expire_on_commit=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chessticulate-api"
-version = "0.9.5"
+version = "0.9.6"
 requires-python = ">=3.11"
 dependencies = ["fastapi[all]", "sqlalchemy >= 2", "httpx", "python-dotenv", "py-bcrypt", "pyjwt", "asyncpg", "aiosqlite"]
 


### PR DESCRIPTION
While testing the frontend, I was getting 500 errors from the API. Looking at the logs, it seems the connection pool was trying to query the database with connections that had timed out. I've added a parameter to the connection pool that will "ping" the database before submitting queries. If the ping fails, it *should* dispose of the connection and reconnect.